### PR TITLE
Db migration fix

### DIFF
--- a/db_migrate.go
+++ b/db_migrate.go
@@ -57,7 +57,7 @@ func verifyMigrationsTable(db *sql.DB) error {
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS migrations (
 		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 		created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-		name TEXT NOT NULL UNIQUE
+		name TEXT NOT NULL UNIQUE CHECK (name <> '')
 	);`)
 	return err
 }

--- a/db_migrate.go
+++ b/db_migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -20,7 +21,10 @@ func runMigrations(db *sql.DB) error {
 		return err
 	}
 
-	for i, file := range AssetNames() {
+	fileNames := AssetNames()
+	sort.Strings(fileNames)
+
+	for i, file := range fileNames {
 		// skip running ones we've clearly already ran
 		if count > 0 {
 			count--


### PR DESCRIPTION
Two little fixes for the migrations:
1) Making sure to run the migration files in the same sequence. Also means you can specify the order by numbering the files.

2) Making sure you don't push a migration with an empty name in case the `fileName` is not parsed correctly (which is happening for me atm, investigating seperately)