### PR TITLE
rework API to fetch posts individually and use Cache-Control

### DIFF
--- a/cmd/hydrocarbon/main.go
+++ b/cmd/hydrocarbon/main.go
@@ -230,7 +230,7 @@ func httpLogger(router http.Handler, prefix string) http.Handler {
 
 func cspMiddleware(router http.Handler, imageDomain string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Content-Security-Policy", fmt.Sprintf(`default-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: %s`, imageDomain))
+		w.Header().Set("Content-Security-Policy", fmt.Sprintf(`default-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: %s; object-src`, imageDomain))
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
 		router.ServeHTTP(w, req)
 	})

--- a/router.go
+++ b/router.go
@@ -95,9 +95,8 @@ func NewRouter(ua *UserAPI, fa *FeedAPI, rs *ReadStatusAPI, domain string) http.
 		var buf []byte
 		if r.URL.Path == "/favicon.ico" {
 			w.Header().Set("Content-Type", "image/png")
-			buf = public.MustAsset("ui/dist/media/favicon.ico")
+			buf = public.MustAsset("ui/dist/media/favicon.9a3c5f4f.ico")
 		} else {
-
 			w.Header().Set("Content-Type", "text/html")
 			buf = public.MustAsset("ui/dist/index.html")
 		}
@@ -122,17 +121,16 @@ func NewRouter(ua *UserAPI, fa *FeedAPI, rs *ReadStatusAPI, domain string) http.
 		// feed management
 		"/v1/feed/create": fa.AddFeed,
 		"/v1/feed/delete": fa.RemoveFeed,
-
-		// list all feeds for a folder
-		"/v1/feed/list": fa.GetFeedsForFolder,
+		// list all posts with no body for a feed
+		"/v1/feed/get": fa.GetFeed,
 
 		// folder management
 		"/v1/folder/create": fa.AddFolder,
-		// list all folders
+		// list all folders with the feed titles
 		"/v1/folder/list": fa.GetFolders,
 
-		// list all posts in a feed
-		"/v1/post/list": fa.GetFeed,
+		// get a post
+		"/v1/post/get": fa.GetPost,
 
 		"/v1/post/read": rs.MarkRead,
 	}
@@ -168,7 +166,7 @@ func (fpr *fixedPathRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	h, ok := fpr.paths[r.URL.Path]
 	if ok {
-		if r.Method != http.MethodPost {
+		if r.Method != http.MethodPost && !strings.Contains(r.URL.Path, "get") {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -21,7 +21,7 @@
 
     <link rel="shortcut icon" href="/favicon.ico">
 
-    <link href="//fonts.googleapis.com/css?family=Fira+Sans:400,500,600" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Fira+Sans:400,500,600" rel="stylesheet">
 </head>
 
 <body>

--- a/ui/src/http/index.js
+++ b/ui/src/http/index.js
@@ -131,15 +131,37 @@ export const createFolder = ({ name, apiKey }) => {
     });
 };
 
-export const listPosts = ({ feedId, apiKey }) => {
-  return fetch("/v1/post/list", {
+export const getFeed = ({ feedId, apiKey }) => {
+  return fetch("/v1/feed/get", {
     method: "POST",
     headers: {
       "x-hydrocarbon-key": apiKey
     },
     body: JSON.stringify({
+      limit: 50,
+      offset: 0,
       feed_id: feedId
     })
+  })
+    .then(response => {
+      if (response.ok) {
+        return response.json();
+      }
+    })
+    .then(json => {
+      if (json.status === "error") {
+        throw json.error;
+      }
+      return json.data;
+    });
+};
+
+export const getPost = ({ postId, apiKey }) => {
+  return fetch(`/v1/post/get?post_id=${postId}`, {
+    method: "GET",
+    headers: {
+      "x-hydrocarbon-key": apiKey
+    }
   })
     .then(response => {
       if (response.ok) {

--- a/ui/src/routes/feed/index.jsx
+++ b/ui/src/routes/feed/index.jsx
@@ -33,21 +33,6 @@ export default class Feed extends Component {
   async componentDidMount(props) {
     try {
       let folders = await listFolders({ apiKey: this.props.apiKey });
-
-      // TODO(fortytw2): push this down to the API layer
-      folders = await Promise.all(
-        folders.map(async f => {
-          const feeds = await listFeeds({
-            apiKey: this.props.apiKey,
-            folderId: f.id
-          });
-          return {
-            ...f,
-            feeds
-          };
-        })
-      );
-
       this.setState({ folders: folders });
     } catch (e) {
       console.log(e);


### PR DESCRIPTION
This massively cleans up our N+1 API calls from the FE. Also fixes some small other bugs and allows any route with `get` in the Path to be queried via http `GET`