### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/discollect/discollector.go
+++ b/discollect/discollector.go
@@ -106,7 +106,7 @@ func (d *Discollector) GetPlugin(name string) (*Plugin, error) {
 	return d.r.Get(name)
 }
 
-// GetPlugin returns the first plugin that matches the given entrypoint
+// PluginForEntrypoint returns the first plugin that matches the given entrypoint
 func (d *Discollector) PluginForEntrypoint(url string, blacklist []string) (*Plugin, *HandlerOpts, error) {
 	plugin, routeParams, err := d.r.PluginFor(url, blacklist)
 	if err != nil {

--- a/pg/db.go
+++ b/pg/db.go
@@ -362,7 +362,7 @@ func (db *DB) RemoveFeed(ctx context.Context, sessionKey, folderID, feedID strin
 	return err
 }
 
-// GetFolders returns all of the folders for a user - if there are none it creates a
+// GetFoldersWithFeeds returns all of the folders for a user - if there are none it creates a
 // default folder
 func (db *DB) GetFoldersWithFeeds(ctx context.Context, sessionKey string) ([]*hydrocarbon.Folder, error) {
 	rows, err := db.sql.QueryContext(ctx, `


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?